### PR TITLE
TEST PR

### DIFF
--- a/base/comps/perl/perl.comp.toml
+++ b/base/comps/perl/perl.comp.toml
@@ -2,3 +2,10 @@
 
 [components.perl.build]
 check = { skip = true, skip_reason = "Disabling checks for initial set of failures." }
+# Workaround: disable SystemTap/DTrace during initial distro bringup to avoid a
+# parallel-make race condition where DynaLoader's sub-make references
+# ../../.dtrace-temp.<hash>.h before the top-level Makefile generates it
+# (sporadic aarch64 failures, no upstream fix — Perl Makefile.SH missing dep).
+# TODO: Re-enable once an upstream fix lands or we carry a Makefile dependency
+# patch.
+without = ["perl_enables_systemtap"]


### PR DESCRIPTION
…e on aarch64

Perl's Makefile.SH has a latent race condition when building with DTrace enabled (-Dusedtrace) and parallel make (-jN). The DynaLoader extension's sub-make references ../../.dtrace-temp.<hash>.h but has no rule to build it — it relies on the top-level Makefile having already generated the file. Under parallel make, the DynaLoader sub-make can start before the dtrace header exists, causing:

  make[1]: *** No rule to make target '../../.dtrace-temp.75709c27.h',
  needed by 'DynaLoader.o'.  Stop.

This is timing-dependent and was observed on aarch64. No upstream fix exists (missing Makefile dependency in Perl's Makefile.SH).

Disable SystemTap/DTrace via build.without = ["perl_enables_systemtap"] as a workaround for initial distro bringup. This can be re-enabled once an upstream Makefile fix lands or we carry a local dependency patch.

Tested: built successfully (x86_64), smoke-tested perl --version and perl -V:usedtrace (confirms usedtrace='undef') in a mock chroot.