### PR TITLE
TEST: cpio fingerprint marker (scoped-render path, no .azldev-version…

### DIFF
--- a/base/comps/cpio/cpio.comp.toml
+++ b/base/comps/cpio/cpio.comp.toml
@@ -1,5 +1,13 @@
 [components.cpio]
 
+# >>> TEST CHANGE (branch: testing/azldev-version-check) -- DO NOT MERGE >>>
+# Changes cpio's config fingerprint so it lands in the post-merge delta render
+# set, WITHOUT touching .azldev-version. Exercises the scoped-render path
+# (RENDER_ALL=false -> post-merge azldev version == base). The macro is
+# unreferenced, so the actual RPM build is unaffected.
+build.defines = { azl_test_marker = "20260619-1" }
+# <<< TEST CHANGE <<<
+
 [[components.cpio.overlays]]
 description = "Drop BR on 'rmt'. Mirroring Rawhide's https://src.fedoraproject.org/rpms/cpio/c/84d5a4fe965609681000fd3911b7246c2a6973fb?branch=rawhide. Required to remove the need for the `star` component (provider of `rmt`)."
 type = "spec-search-replace"


### PR DESCRIPTION
… change)

DO NOT MERGE. Forces cpio into the post-merge delta render set without touching .azldev-version, so the check resolves the post-merge azldev version == base and takes the scoped render path (RENDER_ALL=false).