### PR TITLE
TEST: stale PR — head has old azldev, base bumped (DO NOT MERGE)

### DIFF
--- a/stale-test.txt
+++ b/stale-test.txt
@@ -1,0 +1,7 @@
+Fork CI test artifact — DO NOT MERGE.
+
+"Stale" scenario: this branch does NOT touch .azldev-version (it stays at the
+value it had when the branch was cut). The base branch is then bumped to a
+different azldev version. The check must resolve the POST-merge azldev version
+(= the base's value, via the merge commit), NOT this branch's now-stale value.
+Expected: Build step resolves the base version; render-all=false (scoped path).


### PR DESCRIPTION
Head's .azldev-version is unchanged (A=0256227f); base was bumped to B=44f81cce. The check must resolve the POST-merge version = B (base), NOT the head's A. Expect: 'Resolved post-merge azldev version: 44f81cce...' and RENDER_ALL=false (scoped).